### PR TITLE
let Heroku manage the server port

### DIFF
--- a/youcoach-backend/Procfile
+++ b/youcoach-backend/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar target/youcoach-backend-1.0-SNAPSHOT.jar


### PR DESCRIPTION
On Heroku, Tomcat cannot run on port 8080.
It is decided by Heroku what this port should be (and it probably changes everytime).

To achieve this, the Spring Boot application should be started with the command -Dserver.port=$PORT.
The Procfile takes care of this.